### PR TITLE
Add drag and drop list

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "markdown": "^0.5.0",
     "popper.js": "^1.14.4",
     "react": "^16.7.0",
+    "react-beautiful-dnd": "^10.1.0",
     "react-dom": "^16.7.0",
     "react-firebaseui": "^3.1.2",
     "react-google-login": "^4.0.0",

--- a/src/pages/home/column.js
+++ b/src/pages/home/column.js
@@ -1,18 +1,37 @@
 import React, { Component } from 'react';
 import Note from '../note/note';
 import './home.css';
+import { Droppable } from 'react-beautiful-dnd';
 
 
 export default class Column extends Component {
+
     render() {
         return (
-            <div class="notesContainer">
+            <div class="notesContainer" style={{width: 400, margin: 'auto'}}>
                 <header>
                     <h2>{this.props.column.title}</h2>
                 </header>
-                <div>
-                   {this.props.notes.map(note => <Note key={note.id} noteList={note.noteList} noteTitle={note.noteTitle} noteData={note.noteData} noteId={note.id} removeNote={this.removeNote} /> )} 
-                </div>
+                <Droppable droppableId={this.props.column.id}>
+                    {(provided) => (
+                        <div 
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        >
+                            {this.props.notes.map((note, index) => {
+                                return <Note 
+                                    key={note.id} 
+                                    noteList={note.noteList} 
+                                    noteTitle={note.noteTitle} 
+                                    noteData={note.noteData} 
+                                    noteId={note.id} 
+                                    removeNote={this.removeNote} 
+                                    index={index} /> 
+                            })}
+                            {provided.placeholder} 
+                        </div>
+                    )}  
+                </Droppable>
             </div>
         )
     }

--- a/src/pages/home/column.js
+++ b/src/pages/home/column.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import Note from '../note/note';
+import './home.css';
+
+
+export default class Column extends Component {
+    render() {
+        return (
+            <div class="notesContainer">
+                <header>
+                    <h2>{this.props.column.title}</h2>
+                </header>
+                <div>
+                   {this.props.notes.map(note => <Note key={note.id} noteList={note.noteList} noteTitle={note.noteTitle} noteData={note.noteData} noteId={note.id} removeNote={this.removeNote} /> )} 
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/pages/home/column.js
+++ b/src/pages/home/column.js
@@ -5,7 +5,7 @@ import { Droppable } from 'react-beautiful-dnd';
 
 
 export default class Column extends Component {
-
+    
     render() {
         return (
             <div class="notesContainer" style={{width: 400, margin: 'auto'}}>

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -110,3 +110,8 @@ footer {
 span {
 	font-size: 20px;
 }
+
+.notesContainer {
+	margin: 8px;
+	border: 1px solid lightgrey;
+}

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -5,6 +5,7 @@ import Note from '../note/note';
 import NoteForm from '../noteForm/noteForm';
 import SearchInput, {createFilter} from 'react-search-input';
 import './home.css';
+import Column from './column'
 
 const KEYS_TO_FILTERS = ['noteData', 'noteList', 'noteTitle'];
 export default class Home extends Component {
@@ -18,6 +19,14 @@ export default class Home extends Component {
         this.searchUpdated = this.searchUpdated.bind(this)
         this.state = {
             notes: [],
+            columns: {
+                'column-1': {
+                    id: 'column-1',
+                    title: 'Notes',
+                    noteIds: []
+                }
+            },
+            columnOrder: ['column-1'],
             searchTerm: '',
             showForm: false
         }
@@ -123,6 +132,7 @@ export default class Home extends Component {
     }
     render() {
         const filteredNotes = this.state.notes.filter(createFilter(this.state.searchTerm, KEYS_TO_FILTERS));
+        const column = this.state.columns['column-1'];
         return (
             <div className="bodyapp">
             <header>
@@ -139,6 +149,7 @@ export default class Home extends Component {
                 </div>
             }
             <div className="NotesArray Note">
+                {/* <Column key={column.id} column={column} notes={filteredNotes} /> */}     
                 {
                     filteredNotes.map((note) => {
                         return (

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -5,6 +5,8 @@ import NoteForm from '../noteForm/noteForm';
 import SearchInput, {createFilter} from 'react-search-input';
 import './home.css';
 import Column from './column'
+import { DragDropContext } from 'react-beautiful-dnd';
+
 
 const KEYS_TO_FILTERS = ['noteData', 'noteList', 'noteTitle'];
 export default class Home extends Component {
@@ -129,6 +131,11 @@ export default class Home extends Component {
             }
         });
     }
+
+    onDragEnd = result => {
+        //reorder column
+    }
+
     render() {
         const filteredNotes = this.state.notes.filter(createFilter(this.state.searchTerm, KEYS_TO_FILTERS));
         const column = this.state.columns['column-1'];
@@ -147,9 +154,12 @@ export default class Home extends Component {
                 </div>
                 </div>
             }
-            <div className="NotesArray Note">
-                <Column key={column.id} column={column} notes={filteredNotes} />
-            </div>
+            <DragDropContext onDragEnd={this.onDragEnd}>
+                <div className="NotesArray Note">
+                    <Column key={column.id} column={column} notes={filteredNotes} />
+                </div>
+            </DragDropContext>
+
             <footer>
                 <SearchInput className="search-input" onChange={this.searchUpdated} />
                 <button onClick={this.deleteAcc} type="submit" className="delete">Delete Acc</button>

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import {markdown} from 'markdown';
 import fire from '../../config/fire';
-import Note from '../note/note';
 import NoteForm from '../noteForm/noteForm';
 import SearchInput, {createFilter} from 'react-search-input';
 import './home.css';
@@ -149,14 +148,7 @@ export default class Home extends Component {
                 </div>
             }
             <div className="NotesArray Note">
-                {/* <Column key={column.id} column={column} notes={filteredNotes} /> */}     
-                {
-                    filteredNotes.map((note) => {
-                        return (
-                            <Note key={note.id} noteList={note.noteList} noteTitle={note.noteTitle} noteData={note.noteData} noteId={note.id} removeNote={this.removeNote} />
-                        );
-                    })
-                }
+                <Column key={column.id} column={column} notes={filteredNotes} />
             </div>
             <footer>
                 <SearchInput className="search-input" onChange={this.searchUpdated} />

--- a/src/pages/note/note.js
+++ b/src/pages/note/note.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import './note.css';
+import { Draggable } from 'react-beautiful-dnd';
 
 export default class Note extends Component {
     constructor(props) {
@@ -39,41 +40,52 @@ export default class Note extends Component {
     render() {
         //alert(this.noteData.src);
         return (
-            <div className="card notes" style={{width: 20 + 'rem',display:"inline-block",margin:"1%"}}>
-                <div className="buttonbar">
-                <button onClick={()=> this.handleRemoveNote(this.noteId)} type="submit" className="cross">&otimes;</button>
-                </div>
-                <div className="card-body cdb">
-                {
-                    this.noteTitle === "" ? <h5 className="card-title cdt" ref={this.cardTitle}>New Note</h5>
-                    :
-                    <h5 className="card-title cdt" ref={this.cardTitle}>{this.noteTitle}</h5>
-                }  
-                <hr className="hr"></hr>
-                {
-                    this.props.noteList.length ?
-                        <div className="card-text cdli" ref = {this.cardList}>
+            <Draggable draggableId={this.props.noteId} index={this.props.index}>
+                {(provided) => (
+                    <div 
+                        className="card notes" 
+                        style={{width: 20 + 'rem', margin:"auto", marginBottom: 8}} 
+                        {...provided.draggableProps} 
+                        {...provided.dragHandleProps} 
+                        innerRef={provided.innerRef} 
+                        ref={provided.innerRef}
+                    >
+                        <div className="buttonbar">
+                            <button onClick={()=> this.handleRemoveNote(this.noteId)} type="submit" className="cross">&otimes;</button>
                         </div>
-                        :    
-                        <div>
+                        <div className="card-body cdb">
                             {
-                                this.noteData ?
-                                    <div className="card-text cdte" ref={this.cardText}></div> 
-                                    : 
+                                this.noteTitle === "" ? <h5 className="card-title cdt" ref={this.cardTitle}>New Note</h5>
+                                :
+                                <h5 className="card-title cdt" ref={this.cardTitle}>{this.noteTitle}</h5>
+                            }  
+                            <hr className="hr"></hr>
+                            {
+                                this.props.noteList.length ?
+                                    <div className="card-text cdli" ref = {this.cardList}>
+                                    </div>
+                                :    
+                                <div>
+                                    {
+                                        this.noteData ?
+                                            <div className="card-text cdte" ref={this.cardText}></div> 
+                                            : 
+                                            null
+                                    }
+                                </div>
+                            }
+                            {
+                                !this.noteTitle && !this.props.noteList.length && !this.noteData ?
+                                    <div>
+                                        <div className="empty">THIS NOTE IS EMPTY. PLEASE DELETE IT.</div>
+                                    </div>
+                                    :
                                     null
                             }
                         </div>
-                }
-                {
-                    !this.noteTitle && !this.props.noteList.length && !this.noteData ?
-                        <div>
-                            <div className="empty">THIS NOTE IS EMPTY. PLEASE DELETE IT.</div>
-                        </div>
-                        :
-                        null
-                }
-                </div>
-            </div> 
+                    </div> 
+                )}
+            </Draggable>
         );
     }
 }


### PR DESCRIPTION
# Fixes

Places all created notes within a column, wherein the notes can be dragged and dropped in any order. The drag handle is currently the note itself. 

## New/Remaining Issues

- Last added note does not appear until a new note is created

- Deleting a note is still possible, but the page does not refresh as intended. Rather, a TypeError is thrown (TypeError: this.props.removeNote is not a function)

## Related Issues

[issue #44](https://github.com/nityanandagohain/keep_clone/issues/44)
